### PR TITLE
Update repo location in README and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/mpeterson/rdo-openshift-tools
 2. Clone this repo
 
 ```
-git clone https://github.com/gshipley/installcentos.git
+git clone https://github.com/okd-community-install/installcentos.git
 ```
 
 3. Execute the installation script
@@ -59,7 +59,7 @@ $ export DISK="/dev/sda"
 3. Run the automagic installation script as root with the environment variable in place:
 
 ```
-curl https://raw.githubusercontent.com/gshipley/installcentos/master/install-openshift.sh | INTERACTIVE=false /bin/bash
+curl https://raw.githubusercontent.com/okd-community-install/installcentos/master/install-openshift.sh | INTERACTIVE=false /bin/bash
 ```
 
 ## Development
@@ -68,7 +68,7 @@ For development it's possible to switch the script repo
 
 ```
 # Change location of source repository
-$ export SCRIPT_REPO="https://raw.githubusercontent.com/gshipley/installcentos/master"
+$ export SCRIPT_REPO="https://raw.githubusercontent.com/okd-community-install/installcentos/master"
 $ curl $SCRIPT_REPO/install-openshift.sh | /bin/bash
 ```
 

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -9,7 +9,7 @@ export DOMAIN=${DOMAIN:="$(curl -s ipinfo.io/ip).nip.io"}
 export USERNAME=${USERNAME:="$(whoami)"}
 export PASSWORD=${PASSWORD:=password}
 export VERSION=${VERSION:="3.11"}
-export SCRIPT_REPO=${SCRIPT_REPO:="https://raw.githubusercontent.com/gshipley/installcentos/master"}
+export SCRIPT_REPO=${SCRIPT_REPO:="https://raw.githubusercontent.com/okd-community-install/installcentos/master"}
 export IP=${IP:="$(ip route get 8.8.8.8 | awk '{print $NF; exit}')"}
 export API_PORT=${API_PORT:="8443"}
 export LETSENCRYPT=${LETSENCRYPT:="false"}

--- a/validate/run.sh
+++ b/validate/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl https://raw.githubusercontent.com/gshipley/installcentos/master/install-openshift.sh | INTERACTIVE=false /bin/bash
+curl https://raw.githubusercontent.com/okd-community-install/installcentos/master/install-openshift.sh | INTERACTIVE=false /bin/bash


### PR DESCRIPTION
I discovered while running through the installation that several pieces
of documentation and scripts still referenced the old repository
location under gshipley. This change updates all references to the old
gshipley github org to the new okd-community-install owner.