### PR TITLE
Possibility to select CloudFlare as DNS provider

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -67,7 +67,7 @@ if [ "$INTERACTIVE" = "true" ]; then
 			export MAIL="$choice";
 		fi
 
-		echo "Are you using ClodFlare as DNS-Provider?"
+		echo "Are you using CloudFlare as DNS-Provider?"
 		select yn in "Yes" "No"; do
 			case $yn in
 				Yes) export CLOUDFLARE=true; break;;

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -210,12 +210,14 @@ then
 		mkdir ~/.secrets
 		mkdir ~/.secrets/certbot
 
-		cat <<EOT >> cloudflare.ini
+		cat <<EOT >> ~/.secrets/certbot/cloudflare.ini
 
 		# Cloudflare API credentials used by Certbot
 		dns_cloudflare_email = ${CF_MAIL}
 		dns_cloudflare_api_key = ${CF_KEY}
 EOT
+
+		chmod 600 ~/.secrets/certbot/cloudflare.ini
 
 		# Configure Let's Encrypt certificate
 		certbot certonly --dns-cloudflare \

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -210,15 +210,12 @@ then
 		mkdir ~/.secrets
 		mkdir ~/.secrets/certbot
 
-		cat << EOF >> ~/.secrets/certbot/cloudflare.ini
+		cat <<EOT >> cloudflare.ini
 
 		# Cloudflare API credentials used by Certbot
-		dns_cloudflare_email = $CF_MAIL
-		dns_cloudflare_api_key = $CF_KEY
-
-		EOF
-
-
+		dns_cloudflare_email = ${CF_MAIL}
+		dns_cloudflare_api_key = ${CF_KEY}
+EOT
 
 		# Configure Let's Encrypt certificate
 		certbot certonly --dns-cloudflare \


### PR DESCRIPTION
Added possibility to select CloudFlare as DNS provider and enter account email and global api key for automatic renewal of lets encrypt certificates.