### PR TITLE
Fix image URL for registry-console pod

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -269,6 +269,9 @@ EOT
 	rm certbotcron
 fi
 
+mkdir -p /etc/rhsm/ca
+openssl s_client -showcerts -servername registry.access.redhat.com -connect registry.access.redhat.com:443 </dev/null 2>/dev/null | openssl x509 -text > /etc/rhsm/ca/redhat-uep.pem
+
 mkdir -p /etc/origin/master/
 touch /etc/origin/master/htpasswd
 

--- a/inventory.ini
+++ b/inventory.ini
@@ -45,3 +45,5 @@ openshift_public_hostname=console.${DOMAIN}
 openshift_master_default_subdomain=apps.${DOMAIN}
 openshift_master_api_port=${API_PORT}
 openshift_master_console_port=${API_PORT}
+
+openshift_cockpit_deployer_image="registry.access.redhat.com/openshift3/registry-console:v${VERSION}"


### PR DESCRIPTION
As described in this PR (https://github.com/openshift/openshift-ansible/pull/12122) the cockpit/kubernetes image [1] used by the registry-console pod has been retired and the openshift3/registry-console image from redhat [2] should be used instead.

This PR adapts the ansible `inventory.ini` template file to specify the new location to the redhat image by defining the `openshift_cockpit_deployer_image` variable and hence overriding the default image taken from the playbooks.

Until this gets fixed directly in the PR of the openshift/openshift-ansible repo mentioned above one can use this workaround so that this installation script fully succeeds to install OKD. Without this fix one ends up with a broken registry-console pod at the end of the installation...

Note that the redhat registry certificate is required in order to download their image that's why it gets downloaded before running the ansible playbooks.

Thank you for your consideration.

[1] https://hub.docker.com/r/cockpit/kubernetes
[2] https://access.redhat.com/containers/#/registry.access.redhat.com/openshift3/registry-console

